### PR TITLE
added AsciiDoc style rules to DocGen guidelines

### DIFF
--- a/README.asciidoc
+++ b/README.asciidoc
@@ -129,6 +129,114 @@ image::http://devonfw.github.io/devon4j/images/MyImage.svg["alt-text", width="45
 ** `devon-*` is used for pages that are about the devonfw itself and will not be part of the official documentation.
 ** `tutorial-*` is used for pages that are part of the tutorials.
 
+=== Text styles
+
+_Italic Text_
+
+[source]
+----
+_Italic Text_
+----
+
+*Bold Text*
+
+[source]
+----
+*Bold Text*
+----
+
++Mono Spaced Text+
+
+[source]
+----
++Mono Spaced Text+
+----
+
+Text in ^Superscript^
+
+[source]
+----
+Text in ^Superscript^
+----
+
+Text in ~Subscript~
+
+[source]
+----
+Text in ~Subscript~
+----
+
+=== Titles
+
+A title can be initiated like this:
+
+[source]
+----
+= Level 1 header
+== Level 2 header
+== Level 3 header
+...
+----
+
+=== Lists
+
+Ordered and unordered lists can be created like this:
+
+[source]
+----
+Ordered list:
+. Item 1
+. Item 2
+. Item 3
+. ...
+
+Unordered list:
+* Item 1
+* Item 2
+* Item 3
+* ...
+----
+
+=== Tables
+
+The following example shows how a table can be created. Note that the _header_ flag is optional.
+
+[source]
+----
+[options="header"]
+|===
+|Header 1|Header 2| Header 3
+|  Item 1|  Item 2|   Item 3
+|     ...|     ...|      ...
+|===
+----
+
+=== Source Code
+
+If you want to show off some code examples, you can use the _code block_:
+
+[source]
+----
+ [source]
+ ----
+ some source code
+ ----
+----
+
+You can also specify which script language is used. This will allow GitHub to apply a matching color scheme to the code. Therefore, just add the name of the language used:
+
+[source]
+----
+[source, bash]
+----
+
+or
+
+[source]
+----
+[source, java]
+----
+
 == Migration
 If you migrate from devon-docgen 3.x to 4.x generating PDFs, you now have to add `-Doutput.format=pdf` to your maven build command. Similarly, for html generation it would be `-Doutput.format=html`.
 

--- a/README.asciidoc
+++ b/README.asciidoc
@@ -92,7 +92,7 @@ In order to make DocGen work properly please follow these guidelines:
 * Maintain the documentation as collection of wiki pages. 
 * For the wiki usage link (important) pages in the sidebar for navigation.
 * Use http://www.methods.co.nz/asciidoc/[AsciiDoc] for all wiki pages. This is not the default on github. Always switch `Edit mode` to `AsciiDoc` when creating new wiki pages.
-* For help on the syntax consult the http://asciidoctor.org/docs/asciidoc-writers-guide/[writers guide] and the http://powerman.name/doc/asciidoc[cheatsheet]
+* For help on the syntax consult the http://asciidoctor.org/docs/asciidoc-writers-guide/[writers guide] and the https://asciidoctor.org/docs/asciidoc-syntax-quick-reference/[quick reference].
 * Start every page with the following AsciiDoc header:
 +
 [source,asciidoc]
@@ -128,114 +128,6 @@ image::http://devonfw.github.io/devon4j/images/MyImage.svg["alt-text", width="45
 ** `introduction-*` is used for pages that are part of the introduction into the documentation (motivation and general goals).
 ** `devon-*` is used for pages that are about the devonfw itself and will not be part of the official documentation.
 ** `tutorial-*` is used for pages that are part of the tutorials.
-
-=== Text styles
-
-_Italic Text_
-
-[source]
-----
-_Italic Text_
-----
-
-*Bold Text*
-
-[source]
-----
-*Bold Text*
-----
-
-+Mono Spaced Text+
-
-[source]
-----
-+Mono Spaced Text+
-----
-
-Text in ^Superscript^
-
-[source]
-----
-Text in ^Superscript^
-----
-
-Text in ~Subscript~
-
-[source]
-----
-Text in ~Subscript~
-----
-
-=== Titles
-
-A title can be initiated like this:
-
-[source]
-----
-= Level 1 header
-== Level 2 header
-== Level 3 header
-...
-----
-
-=== Lists
-
-Ordered and unordered lists can be created like this:
-
-[source]
-----
-Ordered list:
-. Item 1
-. Item 2
-. Item 3
-. ...
-
-Unordered list:
-* Item 1
-* Item 2
-* Item 3
-* ...
-----
-
-=== Tables
-
-The following example shows how a table can be created. Note that the _header_ flag is optional.
-
-[source]
-----
-[options="header"]
-|===
-|Header 1|Header 2| Header 3
-|  Item 1|  Item 2|   Item 3
-|     ...|     ...|      ...
-|===
-----
-
-=== Source Code
-
-If you want to show off some code examples, you can use the _code block_:
-
-[source]
-----
- [source]
- ----
- some source code
- ----
-----
-
-You can also specify which script language is used. This will allow GitHub to apply a matching color scheme to the code. Therefore, just add the name of the language used:
-
-[source]
-----
-[source, bash]
-----
-
-or
-
-[source]
-----
-[source, java]
-----
 
 == Migration
 If you migrate from devon-docgen 3.x to 4.x generating PDFs, you now have to add `-Doutput.format=pdf` to your maven build command. Similarly, for html generation it would be `-Doutput.format=html`.


### PR DESCRIPTION
 * currently located in [devonfw-guide/general/Contributing-Wiki.asciidoc](https://github.com/devonfw/devonfw-guide/blob/master/general/Contributing-Wiki.asciidoc) (will be removed soon)
* as discussed [here](https://github.com/devonfw/devonfw-guide/pull/49#issuecomment-549338911), the DocGen `README.md` seems to be better suited for this content
